### PR TITLE
fix comment on browser support

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function onPerformance (cb) {
       'measure',
       'navigation',
       'resource',
-      'longtask'    // not implemented yet in any browser
+      'longtask'
     ]
   })
 


### PR DESCRIPTION
Heyo - I just wanted to add a quick comment fix. :)
'longtask' is available since Chrome 58. :)

-> https://youtu.be/6Ljq-Jn-EgU?t=23m34s