### PR TITLE
 Fix in Node 10, closes #10 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 node_js:
-- "7"
-- "8"
-- "9"
+  - "10"
+  - "8"
+  - "6"
 sudo: false
 language: node_js
 script: "npm run test"

--- a/index.js
+++ b/index.js
@@ -32,10 +32,15 @@ function onPerformance (cb) {
 
   global._onperformance = [cb]
   var observer = new PerformanceObserver(parseEntries)
-  setTimeout(function () {
-    parseEntries(performance)
+  // Only necessary in Node >=8.5 <10, Node 10+ doesn't have a global buffer
+  if (performance.getEntries) {
+    setTimeout(function () {
+      parseEntries(performance)
+      observer.observe({ entryTypes: entryTypes })
+    }, 0)
+  } else {
     observer.observe({ entryTypes: entryTypes })
-  }, 0)
+  }
 
   return stop
 
@@ -54,8 +59,8 @@ function onPerformance (cb) {
 
   function clear (entry) {
     var type = entry.entryType
-    if (type === 'measure') performance.clearMeasures(entry.name)
-    else if (type === 'mark') performance.clearMarks(entry.name)
-    else if (type === 'function') performance.clearFunctions(entry.name)
+    // Only necessary in Node >=8.5 <10, Node 10+ doesn't have a global buffer
+    if (type === 'measure' && performance.clearMeasures) performance.clearMeasures(entry.name)
+    else if (type === 'function' && performance.clearFunctions) performance.clearFunctions(entry.name)
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,21 +9,21 @@
   },
   "version": "1.2.1",
   "scripts": {
-    "start": "bankai start test.js",
-    "test": "standard && browserify test | tape-run"
+    "start": "bankai start test/browser.js",
+    "test": "standard && node test && browserify test/browser | tape-run"
   },
   "dependencies": {
     "nanoassert": "^1.1.0",
     "nanoscheduler": "^1.0.0"
   },
   "devDependencies": {
-    "bankai": "^8.0.0",
-    "browserify": "^14.4.0",
-    "dependency-check": "^2.8.0",
-    "nanotiming": "^5.2.1",
-    "standard": "^10.0.2",
-    "tape": "^4.6.3",
-    "tape-run": "^3.0.0"
+    "bankai": "^9.12.0",
+    "browserify": "^16.2.2",
+    "dependency-check": "^3.1.0",
+    "nanotiming": "^7.3.1",
+    "standard": "^11.0.1",
+    "tape": "^4.9.0",
+    "tape-run": "^4.0.0"
   },
   "keywords": [
     "performance",

--- a/test/browser.js
+++ b/test/browser.js
@@ -1,7 +1,7 @@
 var nanotiming = require('nanotiming')
 var tape = require('tape')
 
-var onPerformance = require('./browser')
+var onPerformance = require('../browser')
 
 tape('should flush already buffered events', function (assert) {
   var startLength = window.performance.getEntries().length

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,17 @@
+var nanotiming = require('nanotiming')
+var tape = require('tape')
+
+var onPerformance = require('../')
+
+tape('should capture performance measures', function (assert) {
+  assert.plan(1)
+
+  var stop = onPerformance(function (entry) {
+    if (entry.entryType !== 'measure') return
+
+    assert.ok(entry, 'entry was passed')
+    stop()
+  })
+
+  nanotiming('test')()
+})

--- a/test/index.js
+++ b/test/index.js
@@ -2,8 +2,16 @@ var nanotiming = require('nanotiming')
 var tape = require('tape')
 
 var onPerformance = require('../')
+var hasPerfHooks = (function () {
+  try {
+    require('perf_hooks')
+    return true
+  } catch (err) {
+    return false
+  }
+}())
 
-tape('should capture performance measures', function (assert) {
+tape('should capture performance measures', { skip: !hasPerfHooks }, function (assert) {
   assert.plan(1)
 
   var stop = onPerformance(function (entry) {


### PR DESCRIPTION
- Add a test for a single performance measurement in Node.
- Add Node 10 to CI
- If `perf_hooks.performance` has a global buffer, use it, else don't! This means it should still work in node >=8.5 <10 too